### PR TITLE
Bulletin nav

### DIFF
--- a/pages/community/bulletins/index.js
+++ b/pages/community/bulletins/index.js
@@ -1,8 +1,8 @@
 import SingleColumnLayout from "../../../components/layouts/single-column";
 import BulletinList from '../../../components/bulletins/bulletin-list';
 import { fetcher } from '../../../util/crud';
-
 import useSWR from 'swr';
+import Link from 'next/link';
 
 export async function getStaticProps() {
     const posts = await fetcher('https://music-scene-api.herokuapp.com/api/bulletin_board/items/');
@@ -17,7 +17,12 @@ export default function Bulletins(props) {
 
     return (
         <SingleColumnLayout>
-            {<BulletinList bulletins={data} />}
+            <div>
+                <Link href='/community/bulletins/new'>
+                    <a>New bulletin</a>
+                </Link>
+            </div>
+            <BulletinList bulletins={data} />
         </SingleColumnLayout>
     );
 }

--- a/pages/community/bulletins/index.js
+++ b/pages/community/bulletins/index.js
@@ -10,9 +10,12 @@ export async function getStaticProps() {
 }
 
 export default function Bulletins(props) {
-    const { data, error } = useSWR('https://music-scene-api.herokuapp.com/api/bulletin_board/items/', fetcher, { initialData: props.posts });
+    const { data, err } = useSWR('https://music-scene-api.herokuapp.com/api/bulletin_board/items/', fetcher, { initialData: props.posts });
 
-    if (error) return <div>failed to load</div>
+    if (err) {
+        console.log('Error fetching: ', err);
+        return <div>failed to load</div>;
+    }
     if (!data) return <div>loading...</div>
 
     return (

--- a/pages/community/bulletins/new.js
+++ b/pages/community/bulletins/new.js
@@ -1,7 +1,7 @@
 import SingleColumnLayout from '../../../components/layouts/single-column';
 import { poster } from '../../../util/crud';
-
 import { useForm } from 'react-hook-form';
+import Link from 'next/link';
 
 const NewBulletin = () => {
     const { register, handleSubmit, errors } = useForm(),
@@ -24,6 +24,9 @@ const NewBulletin = () => {
                     <div className="field-error">{errors.content && 'Please enter some content for your post.'}</div>
                 </div>
                 <input type='submit' />
+                <Link href='/community/bulletins/'>
+                    <a>Back to bulletins</a>
+                </Link>
             </form>
         </SingleColumnLayout>
     );

--- a/util/crud.js
+++ b/util/crud.js
@@ -1,6 +1,14 @@
 import Router from 'next/router';
 
-export const fetcher = async (...args) => fetch(...args).then(res => res.json());
+export const fetcher = async (...args) => {
+    try {
+        const res = await fetch(...args, { mode: 'no-cors' });
+        return res.json();
+    }
+    catch (err) {
+        console.error(err);
+    }
+};
 
 export const poster = async ({ title, content }) => {
     try {
@@ -15,7 +23,7 @@ export const poster = async ({ title, content }) => {
         });
         await Router.push('/community/bulletins/');
     }
-    catch (error) {
-        console.error(error);
+    catch (err) {
+        console.error(err);
     }
 }


### PR DESCRIPTION
Adds simple link from bulletin list to new form, and a simple link from the new form back to the list (like cancel). (ben's issue 8)

I can change to buttons and/or add some basic style. We could also add some sort of menu bar that persists from list to form, including buttons like "New", "Submit" and "Cancel". Food for thought.

Also adds no-cors to GET requests to fix a loading error after the initial load. (ben's issue 7)